### PR TITLE
Change Magma to extend std::ops::Add

### DIFF
--- a/src/magma.rs
+++ b/src/magma.rs
@@ -1,5 +1,17 @@
+use std::ops::{Add};
+
 pub trait Magma<T> {
     fn add(&self, other: &T) -> T;
+}
+
+impl<T: Magma<T>> Add for T
+where T: Magma<T>
+{
+    type Output = T;
+
+    fn add(self, rhs: &T) -> T {
+        return self.add(rhs);
+    }
 }
 
 #[cfg(test)]
@@ -13,9 +25,29 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy)]
+    struct Foo {
+        x: i32,
+    }
+
+    impl Magma<Foo> for Foo {
+        fn add(&self, other: &Foo) -> Foo {
+            return Foo {
+                x: self.x + other.x
+            };
+        }
+    }
+
     #[test]
     fn i32_is_a_magma() {
         let x: i32 = 2;
         assert_eq!(x.add(&2), 4);
+    }
+
+    #[test]
+    fn foo_is_magma_with_operator_overloading() {
+        let foo_x = Foo { x: 2 };
+        let foo_y = Foo { x: 3 };
+        assert_eq!(foo_x + foo_y, Foo { x: 5 });
     }
 }

--- a/src/magma.rs
+++ b/src/magma.rs
@@ -1,18 +1,6 @@
 use std::ops::{Add};
 
-pub trait Magma<T> {
-    fn add(&self, other: &T) -> T;
-}
-
-impl<T: Magma<T>> Add for T
-where T: Magma<T>
-{
-    type Output = T;
-
-    fn add(self, rhs: &T) -> T {
-        return self.add(rhs);
-    }
-}
+pub trait Magma<T>: Add<T, Output=T> {}
 
 #[cfg(test)]
 mod tests {
@@ -20,22 +8,24 @@ mod tests {
 
     // implement Magma for type i32
     impl Magma<i32> for i32 {
-        fn add(&self, other: &i32) -> i32 {
-            return self + other;
-        }
+
     }
 
-    #[derive(Clone, Copy)]
+    // define custom struct and implement Magma
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     struct Foo {
         x: i32,
     }
 
-    impl Magma<Foo> for Foo {
-        fn add(&self, other: &Foo) -> Foo {
-            return Foo {
-                x: self.x + other.x
-            };
+    impl Add for Foo {
+        type Output = Foo;
+
+        fn add(self, rhs: Foo) -> Foo {
+            return Foo{x: self.x + rhs.x}
         }
+    }
+
+    impl Magma<Foo> for Foo {
     }
 
     #[test]
@@ -49,5 +39,6 @@ mod tests {
         let foo_x = Foo { x: 2 };
         let foo_y = Foo { x: 3 };
         assert_eq!(foo_x + foo_y, Foo { x: 5 });
+        assert_eq!(foo_x.add(foo_y), Foo { x: 5 });
     }
 }

--- a/src/magma.rs
+++ b/src/magma.rs
@@ -1,5 +1,7 @@
 use std::ops::{Add};
 
+/// A Magma defines a binary operation 'add' over type `T`
+/// such that the operation is closed.
 pub trait Magma<T>: Add<T, Output=T> {}
 
 #[cfg(test)]

--- a/src/magma.rs
+++ b/src/magma.rs
@@ -1,7 +1,8 @@
 use std::ops::{Add};
 
-/// A Magma defines a binary operation 'add' over type `T`
-/// such that the operation is closed.
+/// A Magma defines a binary operation 'add' (denoted hereafter by `+`)
+/// over type `T` with the following properties:
+/// * `+` is closed over type `T`
 pub trait Magma<T>: Add<T, Output=T> {}
 
 #[cfg(test)]


### PR DESCRIPTION
* Change the Magma trait to be an extension of `std::ops::Add` where the type
  bounds are restricted such that the add operation is closed under type `T`.