### PR TITLE
initial work on unital magma

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rand = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 mod magma;
+mod unital_magma;

--- a/src/magma.rs
+++ b/src/magma.rs
@@ -1,16 +1,18 @@
-use std::ops::Add;
+use std::ops::{Add};
 
 /// A Magma defines a binary operation 'add' (denoted hereafter by `+`)
 /// over type `T` with the following properties:
-/// * `+` is closed over type `T`
-pub trait Magma<T>: Add<T, Output = T> {}
+/// * `+` is [closed](https://proofwiki.org/wiki/Definition:Closure_(Abstract_Algebra)/Algebraic_Structure) over type `T`
+pub trait Magma<T>: Add<T, Output=T> {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     // implement Magma for type i32
-    impl Magma<i32> for i32 {}
+    impl Magma<i32> for i32 {
+
+    }
 
     // define custom struct and implement Magma
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -22,11 +24,12 @@ mod tests {
         type Output = Foo;
 
         fn add(self, rhs: Foo) -> Foo {
-            return Foo { x: self.x + rhs.x };
+            return Foo{x: self.x + rhs.x}
         }
     }
 
-    impl Magma<Foo> for Foo {}
+    impl Magma<Foo> for Foo {
+    }
 
     #[test]
     fn i32_is_a_magma() {

--- a/src/magma.rs
+++ b/src/magma.rs
@@ -1,18 +1,16 @@
-use std::ops::{Add};
+use std::ops::Add;
 
 /// A Magma defines a binary operation 'add' (denoted hereafter by `+`)
 /// over type `T` with the following properties:
 /// * `+` is [closed](https://proofwiki.org/wiki/Definition:Closure_(Abstract_Algebra)/Algebraic_Structure) over type `T`
-pub trait Magma<T>: Add<T, Output=T> {}
+pub trait Magma<T>: Add<T, Output = T> {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     // implement Magma for type i32
-    impl Magma<i32> for i32 {
-
-    }
+    impl Magma<i32> for i32 {}
 
     // define custom struct and implement Magma
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -24,12 +22,11 @@ mod tests {
         type Output = Foo;
 
         fn add(self, rhs: Foo) -> Foo {
-            return Foo{x: self.x + rhs.x}
+            return Foo { x: self.x + rhs.x };
         }
     }
 
-    impl Magma<Foo> for Foo {
-    }
+    impl Magma<Foo> for Foo {}
 
     #[test]
     fn i32_is_a_magma() {

--- a/src/unital_magma.rs
+++ b/src/unital_magma.rs
@@ -12,7 +12,7 @@ use crate::magma::Magma;
 /// and a [right identity](https://proofwiki.org/wiki/Definition:Identity_(Abstract_Algebra)/Right_Identity)
 /// under `+`
 pub trait UnitalMagma<T>: Magma<T> {
-    fn identity_element() -> T;
+    const IDENTITY: T;
 }
 
 //[identity element] on T
@@ -20,24 +20,19 @@ pub trait UnitalMagma<T>: Magma<T> {
 mod tests {
     use rand::Rng;
     use super::*;
-    impl UnitalMagma<i32> for i32 { fn identity_element() -> i32 { 0 } }
+    impl UnitalMagma<i32> for i32 { const IDENTITY: i32 = 0; }
 
     #[test]
     fn idenenty_element_is_left_identity() {
         let mut rng = rand::thread_rng();
         let random_val = rng.gen_range(-100..=100);
-        assert_eq!(i32::identity_element() + random_val, random_val)
+        assert_eq!(i32::IDENTITY + random_val, random_val)
     }
 
     #[test]
     fn idenenty_element_is_right_identity() {
         let mut rng = rand::thread_rng();
         let random_val = rng.gen_range(-100..=100);
-        assert_eq!(random_val + i32::identity_element(), random_val)
-    }
-
-    #[test]
-    fn identity_element_unique() {
-        assert_eq!(i32::identity_element(), i32::identity_element())
+        assert_eq!(random_val + i32::IDENTITY, random_val)
     }
 }

--- a/src/unital_magma.rs
+++ b/src/unital_magma.rs
@@ -23,14 +23,14 @@ mod tests {
     impl UnitalMagma<i32> for i32 { const IDENTITY: i32 = 0; }
 
     #[test]
-    fn idenenty_element_is_left_identity() {
+    fn identity_element_is_left_identity() {
         let mut rng = rand::thread_rng();
         let random_val = rng.gen_range(-100..=100);
         assert_eq!(i32::IDENTITY + random_val, random_val)
     }
 
     #[test]
-    fn idenenty_element_is_right_identity() {
+    fn identity_element_is_right_identity() {
         let mut rng = rand::thread_rng();
         let random_val = rng.gen_range(-100..=100);
         assert_eq!(random_val + i32::IDENTITY, random_val)

--- a/src/unital_magma.rs
+++ b/src/unital_magma.rs
@@ -18,9 +18,11 @@ pub trait UnitalMagma<T>: Magma<T> {
 //[identity element] on T
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
     use super::*;
-    impl UnitalMagma<i32> for i32 { const IDENTITY: i32 = 0; }
+    use rand::Rng;
+    impl UnitalMagma<i32> for i32 {
+        const IDENTITY: i32 = 0;
+    }
 
     #[test]
     fn identity_element_is_left_identity() {

--- a/src/unital_magma.rs
+++ b/src/unital_magma.rs
@@ -1,0 +1,37 @@
+use crate::magma::Magma;
+
+/// A Unital Magma is a [`Magma`] equipped
+/// with an [identity](https://proofwiki.org/wiki/Definition:Identity_(Abstract_Algebra)/Two-Sided_Identity) element.
+///<br><br>i.e.<br><br>
+/// A Unital [`Magma`] defines a binary operation
+/// 'add' (denoted hereafter by `+`)
+/// over type `T`, and a unique element of T (denoted hereafter by `e`)
+/// with the following properties:
+/// * `+` is [closed](https://proofwiki.org/wiki/Definition:Closure_(Abstract_Algebra)/Algebraic_Structure) over type `T`
+/// * `e` is both a [left identity](https://proofwiki.org/wiki/Definition:Identity_(Abstract_Algebra)/Left_Identity)
+/// and a [right identity](https://proofwiki.org/wiki/Definition:Identity_(Abstract_Algebra)/Right_Identity)
+/// under `+`
+pub trait UnitalMagma<T>: Magma<T> {
+    fn identity_element() -> T;
+}
+
+//[identity element] on T
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+    use super::*;
+    impl UnitalMagma<i32> for i32 { fn identity_element() -> i32 { 0 } }
+
+    #[test]
+    fn idenenty_element_is_left_identity() {
+        let mut rng = rand::thread_rng();
+        let random_val = rng.gen_range(-100..=100);
+        assert_eq!(i32::identity_element() + random_val, random_val)
+    }
+
+    fn idenenty_element_is_right_identity() {
+        let mut rng = rand::thread_rng();
+        let random_val = rng.gen_range(-100..=100);
+        assert_eq!(random_val + i32::identity_element(), random_val)
+    }
+}

--- a/src/unital_magma.rs
+++ b/src/unital_magma.rs
@@ -29,9 +29,15 @@ mod tests {
         assert_eq!(i32::identity_element() + random_val, random_val)
     }
 
+    #[test]
     fn idenenty_element_is_right_identity() {
         let mut rng = rand::thread_rng();
         let random_val = rng.gen_range(-100..=100);
         assert_eq!(random_val + i32::identity_element(), random_val)
+    }
+
+    #[test]
+    fn identity_element_unique() {
+        assert_eq!(i32::identity_element(), i32::identity_element())
     }
 }


### PR DESCRIPTION
Initial work on unital magma i.e. a magma with an identity element often called unit.
All criticism welcome. Question for consideration: Should the supplier function 'identity_element' be called 'unit' instead?